### PR TITLE
Set AppArmor as default security feature

### DIFF
--- a/linux-liquorix/debian/config/kernelarch-x86/config-arch-64
+++ b/linux-liquorix/debian/config/kernelarch-x86/config-arch-64
@@ -9530,10 +9530,10 @@ CONFIG_INTEGRITY_AUDIT=y
 CONFIG_EVM=y
 CONFIG_EVM_ATTR_FSUUID=y
 CONFIG_EVM_ADD_XATTRS=y
-CONFIG_DEFAULT_SECURITY_SELINUX=y
-# CONFIG_DEFAULT_SECURITY_APPARMOR is not set
+# CONFIG_DEFAULT_SECURITY_SELINUX is not set
+CONFIG_DEFAULT_SECURITY_APPARMOR=y
 # CONFIG_DEFAULT_SECURITY_DAC is not set
-CONFIG_LSM="yama,loadpin,safesetid,integrity,selinux,smack,tomoyo,apparmor"
+CONFIG_LSM="lockdown,yama,loadpin,safesetid,integrity,apparmor,selinux,smack,tomoyo,bpf"
 
 #
 # Kernel hardening options


### PR DESCRIPTION
Debian/Ubuntu uses AppArmor and not SELinux as default security feature