### PR TITLE
scripts/debian/add-liquorix-repo.sh: specify "[arch=amd64]"

### DIFF
--- a/scripts/debian/add-liquorix-repo.sh
+++ b/scripts/debian/add-liquorix-repo.sh
@@ -7,41 +7,55 @@ if [[ "$(id -u)" -ne 0 ]]; then
     exit 0
 fi
 
-apt-get install lsb-release -y
-codename="$(lsb_release -cs)"
+case $(uname -m) in
+x86_64)
+    ARCH=x64  # or AMD64 or Intel64 or whatever
+    ;;
+*)
+    echo "ERROR: Architecture not supported."
+    exit
+    ;;
+esac
 
-if [[ -z "$codename" ]]; then
-    echo "[ERROR] Unable to detect system code name!"
-    exit 0
+dist=$(grep '^ID' /etc/os-release | sed 's/ID=//' | head -1)
+if [ "$dist" = "debian" ]; then
+    # Install debian repo
+    apt-get install lsb-release -y
+    mkdir -p /etc/apt/{sources.list.d,trusted.gpg.d}
+    curl -o /etc/apt/trusted.gpg.d/liquorix-keyring.gpg \
+        'https://liquorix.net/liquorix-keyring.gpg'
+    echo ""
+    echo "[INFO ] Liquorix keyring added to /etc/apt/trusted.gpg.d/liquorix-keyring.gpg"
+    echo ""
+
+    apt-get install apt-transport-https -y
+
+    repo_file="/etc/apt/sources.list.d/liquorix.list"
+    repo_code="$(lsb_release -cs)"
+    echo "deb https://liquorix.net/debian $repo_code main"      > $repo_file
+    echo "deb-src https://liquorix.net/debian $repo_code main" >> $repo_file
+
+    apt-get update -y
+    if [ $ARCH = "x64" ]; then
+        sudo apt-get install -y linux-image-liquorix-amd64 linux-headers-liquorix-amd64
+    fi
+
+    echo ""
+    echo "[INFO] Liquorix repository added successfully to $repo_file"
+    echo ""
+elif [ "$dist" = "ubuntu" ]; then
+    echo "Distribution is $dist"
+
+    sudo add-apt-repository ppa:damentz/liquorix && sudo apt-get update
+    if [ $ARCH = "x64" ]; then
+        sudo apt-get install -y linux-image-liquorix-amd64 linux-headers-liquorix-amd64
+    fi
+
+    echo ""
+    echo "[INFO] Liquorix PPA repository added successfully"
+    echo ""
+else
+    echo "ERROR: This distribution is not supported at this time."
+    exit
 fi
 
-mkdir -p /etc/apt/{sources.list.d,trusted.gpg.d}
-
-apt-get install curl -y
-curl -o /etc/apt/trusted.gpg.d/liquorix-keyring.gpg \
-    'https://liquorix.net/liquorix-keyring.gpg'
-
-echo ""
-echo "[INFO ] Liquorix keyring added to /etc/apt/trusted.gpg.d/liquorix-keyring.gpg"
-echo ""
-
-apt-get install apt-transport-https -y
-
-repo_file="/etc/apt/sources.list.d/liquorix.list"
-echo "deb http://liquorix.net/debian $codename main
-deb-src http://liquorix.net/debian $codename main
-
-# Mirrors:
-#
-# Unit193 - France
-# deb http://mirror.unit193.net/liquorix $codename main
-# deb-src http://mirror.unit193.net/liquorix $codename main" > \
-    $repo_file
-
-apt-get update
-
-echo ""
-echo "[INFO ] Liquorix repository added successfully to $repo_file"
-echo ""
-echo "[INFO ] You can now install Liquorix with:"
-echo "[INFO ] sudo apt-get install linux-image-liquorix-amd64 linux-headers-liquorix-amd64"

--- a/scripts/debian/add-liquorix-repo.sh
+++ b/scripts/debian/add-liquorix-repo.sh
@@ -27,8 +27,8 @@ debian)
 
     repo_file="/etc/apt/sources.list.d/liquorix.list"
     repo_code="$(lsb_release -cs)"
-    echo "deb https://liquorix.net/debian $repo_code main"      > $repo_file
-    echo "deb-src https://liquorix.net/debian $repo_code main" >> $repo_file
+    echo "deb [arch=amd64] https://liquorix.net/debian $repo_code main"      > $repo_file
+    echo "deb-src [arch=amd64] https://liquorix.net/debian $repo_code main" >> $repo_file
 
     apt-get update -y
     apt-get install -y linux-image-liquorix-amd64 linux-headers-liquorix-amd64

--- a/scripts/debian/add-liquorix-repo.sh
+++ b/scripts/debian/add-liquorix-repo.sh
@@ -2,23 +2,18 @@
 
 set -euo pipefail
 
-if [[ "$(id -u)" -ne 0 ]]; then
+if [ "$(id -u)" -ne 0 ]; then
     echo "[ERROR] You must run this script as root!"
-    exit 0
+    exit 1
 fi
 
-case $(uname -m) in
-x86_64)
-    ARCH=x64  # or AMD64 or Intel64 or whatever
-    ;;
-*)
-    echo "ERROR: Architecture not supported."
-    exit
-    ;;
-esac
+if [ $(uname -m) != x86_64 ]; then
+    echo "[ERROR] Architecture not supported"
+    exit 1
+fi
 
-dist=$(grep '^ID' /etc/os-release | sed 's/ID=//' | head -1)
-if [ "$dist" = "debian" ]; then
+case $(grep '^ID' /etc/os-release | sed 's/ID=//' | head -1) in
+debian)
     # Install debian repo
     apt-get install lsb-release -y
     mkdir -p /etc/apt/{sources.list.d,trusted.gpg.d}
@@ -36,26 +31,24 @@ if [ "$dist" = "debian" ]; then
     echo "deb-src https://liquorix.net/debian $repo_code main" >> $repo_file
 
     apt-get update -y
-    if [ $ARCH = "x64" ]; then
-        sudo apt-get install -y linux-image-liquorix-amd64 linux-headers-liquorix-amd64
-    fi
+    apt-get install -y linux-image-liquorix-amd64 linux-headers-liquorix-amd64
 
     echo ""
-    echo "[INFO] Liquorix repository added successfully to $repo_file"
+    echo "[INFO ] Liquorix repository added successfully to $repo_file"
     echo ""
-elif [ "$dist" = "ubuntu" ]; then
+    ;;
+ubuntu)
     echo "Distribution is $dist"
 
-    sudo add-apt-repository ppa:damentz/liquorix && sudo apt-get update
-    if [ $ARCH = "x64" ]; then
-        sudo apt-get install -y linux-image-liquorix-amd64 linux-headers-liquorix-amd64
-    fi
+    add-apt-repository ppa:damentz/liquorix && apt-get update
+    apt-get install -y linux-image-liquorix-amd64 linux-headers-liquorix-amd64
 
     echo ""
-    echo "[INFO] Liquorix PPA repository added successfully"
+    echo "[INFO ] Liquorix PPA repository added successfully"
     echo ""
-else
-    echo "ERROR: This distribution is not supported at this time."
-    exit
-fi
-
+    ;;
+*)
+    echo "[ERROR] This distribution is not supported at this time"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
Liquorix has dropped 32-bit support and bullseye/bookworm/sid repositories have removed i386 from their `Architectures`. Unless `[arch=amd64]` is specified, if `i386` is configured as a foreign architecture, APT will show a prompt saying that the Liquorix repository does not support i386.