### PR TITLE
scripts/debian/add-liquorix-repo.sh: suppress dialog, colorize log

### DIFF
--- a/scripts/debian/add-liquorix-repo.sh
+++ b/scripts/debian/add-liquorix-repo.sh
@@ -2,31 +2,44 @@
 
 set -euo pipefail
 
+log() {
+    case "$1" in
+    INFO)
+        echo -e "\033[32m[INFO ] $2\033[0m" # green
+	;;
+    ERROR)
+        echo -e "\033[31m[ERROR] $2\033[0m" # red
+	;;
+    esac
+}
+
 if [ "$(id -u)" -ne 0 ]; then
-    echo "[ERROR] You must run this script as root!"
+    log ERROR "You must run this script as root!"
     exit 1
 fi
 
-if [ $(uname -m) != x86_64 ]; then
-    echo "[ERROR] Architecture not supported"
+if [ "$(uname -m)" != x86_64 ]; then
+    log ERROR "Architecture not supported"
     exit 1
 fi
 
 export DEBIAN_FRONTEND="noninteractive" # `curl <URL> | sudo bash` suppresses stdin
 export NEEDRESTART_SUSPEND="*" # suspend needrestart or it will restart services automatically
 
-case $(grep '^ID' /etc/os-release | sed 's/ID=//' | head -1) in
+dist="$(grep '^ID' /etc/os-release | sed 's/ID=//' | head -1)"
+log INFO "Distribution is $dist"
+
+case "$dist" in
 debian)
     # Install debian repo
-    apt-get install lsb-release -y
     mkdir -p /etc/apt/{sources.list.d,trusted.gpg.d}
     curl -o /etc/apt/trusted.gpg.d/liquorix-keyring.gpg \
         'https://liquorix.net/liquorix-keyring.gpg'
     echo ""
-    echo "[INFO ] Liquorix keyring added to /etc/apt/trusted.gpg.d/liquorix-keyring.gpg"
+    log INFO "Liquorix keyring added to /etc/apt/trusted.gpg.d/liquorix-keyring.gpg"
     echo ""
 
-    apt-get install apt-transport-https -y
+    apt-get install apt-transport-https lsb-release -y
 
     repo_file="/etc/apt/sources.list.d/liquorix.list"
     repo_code="$(lsb_release -cs)"
@@ -34,24 +47,32 @@ debian)
     echo "deb-src [arch=amd64] https://liquorix.net/debian $repo_code main" >> $repo_file
 
     apt-get update -y
+
+    echo ""
+    log INFO "Liquorix repository added successfully to $repo_file"
+    echo ""
+
     apt-get install -y linux-image-liquorix-amd64 linux-headers-liquorix-amd64
 
     echo ""
-    echo "[INFO ] Liquorix repository added successfully to $repo_file"
+    log INFO "Liquorix kernel installed successfully"
     echo ""
     ;;
 ubuntu)
-    echo "Distribution is $dist"
-
     add-apt-repository ppa:damentz/liquorix && apt-get update
+
+    echo ""
+    log INFO "Liquorix PPA repository added successfully"
+    echo ""
+
     apt-get install -y linux-image-liquorix-amd64 linux-headers-liquorix-amd64
 
     echo ""
-    echo "[INFO ] Liquorix PPA repository added successfully"
+    log INFO "Liquorix kernel installed successfully"
     echo ""
     ;;
 *)
-    echo "[ERROR] This distribution is not supported at this time"
+    log ERROR "This distribution is not supported at this time"
     exit 1
     ;;
 esac

--- a/scripts/debian/add-liquorix-repo.sh
+++ b/scripts/debian/add-liquorix-repo.sh
@@ -12,6 +12,9 @@ if [ $(uname -m) != x86_64 ]; then
     exit 1
 fi
 
+export DEBIAN_FRONTEND="noninteractive" # `curl <URL> | sudo bash` suppresses stdin
+export NEEDRESTART_SUSPEND="*" # suspend needrestart or it will restart services automatically
+
 case $(grep '^ID' /etc/os-release | sed 's/ID=//' | head -1) in
 debian)
     # Install debian repo


### PR DESCRIPTION
If the script is executed by `curl <URL> | sudo bash`, stdin will not be tty. We need to make APT non-interactive and suspend needrestart, or it will be a mess.
Also, colorized and adjusted the log a bit.