### PR TITLE
docker_bootstrap: fix GPG key detection

### DIFF
--- a/scripts/debian/docker_bootstrap-image.sh
+++ b/scripts/debian/docker_bootstrap-image.sh
@@ -44,12 +44,12 @@ fi
 declare public="$(gpg --armor --export -a "$default_key")"
 declare secret="$(gpg --armor --export-secret-keys -a "$default_key")"
 
-if echo "$public" | head -n1 | grep -q 'BEGIN PGP PUBLIC KEY BLOCK'; then
+if ! echo "$public" | head -n1 | grep -q 'BEGIN PGP PUBLIC KEY BLOCK'; then
     echo "[ERROR] Exported public key is empty!  Cannot proceed with building bootstrap images."
     exit 1
 fi
 
-if echo "$secret" | head -n1 | grep -q 'BEGIN PGP PRIVATE KEY BLOCK'; then
+if ! echo "$secret" | head -n1 | grep -q 'BEGIN PGP PRIVATE KEY BLOCK'; then
     echo "[ERROR] Exported secret key is empty!  Cannot proceed with building bootstrap images."
     exit 1
 fi


### PR DESCRIPTION
Fix the GPG Key detection wich was added with commit 191b568f7f63af3a0aa0b8d383696730b3d2d6b8.

Without this fix, the error gets triggered when a valid GPG key is found, not the other way around.