### PR TITLE
Add version to provided wireguard-modules in Debian package

### DIFF
--- a/linux-liquorix/debian/templates/control.image.in
+++ b/linux-liquorix/debian/templates/control.image.in
@@ -3,7 +3,7 @@ Depends: kmod, zstd, linux-base (>= 4.3~), ${misc:Depends}
 Recommends: ${kernel:Recommends},
  firmware-linux-free | linux-firmware,
  firmware-linux-nonfree | linux-firmware
-Provides: wireguard-modules
+Provides: wireguard-modules (= 1.0.0)
 Suggests: linux-doc-@version@
 Description: Linux @upstreamversion@ for @class@
  The Linux kernel @upstreamversion@ and modules for use on @longclass@.


### PR DESCRIPTION
Debian's `wireguard` package depends on `wireguard-modules >= 0.0.20191219`, which is incompatible with the version numbers picked by liquorix. Setting the version to `1.0.0`, which is also what `linux-image-*` packages in Debian do, solves the problem.

## Steps to reproduce
Run `apt install wireguard` without any of Debian's `linux-image-*` packages installed.

## Expected behaviour
The operation does not attempt to install `linux-image-amd64`, because liquorix kernel provides WireGuard modules.

## Actual behaviour
The operation attempts to install `linux-image-amd64`, because liquorix does not satisfy `wireguard`'s `wireguard-modules` dependency.