### PR TITLE
feat: Automate GPG key generation and package signing, and remove temremove temporary build mounts from Docker commands.

### DIFF
--- a/scripts/debian/container_build-binary.sh
+++ b/scripts/debian/container_build-binary.sh
@@ -52,7 +52,15 @@ cd "$dir_build/$package_name-$version_kernel"
 mk-build-deps -ir -t 'apt-get -y'
 
 log_info "Building binary package for $release"
-$schedtool dpkg-buildpackage --build=binary
+
+declare gpg_key
+gpg_key=$(awk '/^default-key/ {print $2}' ~/.gnupg/gpg.conf 2>/dev/null || echo "")
+
+if [[ -n "$gpg_key" ]]; then
+    $schedtool dpkg-buildpackage --build=binary -k"$gpg_key"
+else
+    $schedtool dpkg-buildpackage --build=binary
+fi
 
 log_info "Copying binary packages to bind mount: $dir_artifacts/"
 mkdir -p "$dir_artifacts"

--- a/scripts/debian/docker_build-source.sh
+++ b/scripts/debian/docker_build-source.sh
@@ -22,7 +22,6 @@ fi
 
 docker run --net='host' \
     --rm \
-    --tmpfs /build:exec \
     --ulimit nofile=524288:524288 \
     -v "$HOME/.gnupg":/root/.gnupg \
     $(gpg_agent_mount_flags /root) \

--- a/scripts/debian/docker_submit-ppa-sources.sh
+++ b/scripts/debian/docker_submit-ppa-sources.sh
@@ -17,7 +17,6 @@ for release in "${releases_ubuntu[@]}"; do
     log_info "Uploading sources for $distro/$release"
     docker run --net='host' \
     --rm \
-    --tmpfs /build:exec \
     --env LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libeatmydata.so \
     -v "$HOME/.gnupg":/root/.gnupg \
     $(gpg_agent_mount_flags /root) \

--- a/scripts/debian/env.sh
+++ b/scripts/debian/env.sh
@@ -122,5 +122,12 @@ function build_source_package {
         dpkg-source --commit . ci.patch
 
     log_info "Making source package"
-    $schedtool dpkg-buildpackage --build=source
+    local gpg_key
+    gpg_key=$(awk '/^default-key/ {print $2}' ~/.gnupg/gpg.conf 2>/dev/null || echo "")
+
+    if [[ -n "$gpg_key" ]]; then
+        $schedtool dpkg-buildpackage --build=source -k"$gpg_key"
+    else
+        $schedtool dpkg-buildpackage --build=source
+    fi
 }

--- a/scripts/generate_gpg_key.sh
+++ b/scripts/generate_gpg_key.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euo pipefail
+
+# Allow user to specify Name and Email, defaulting to liquorix builder defaults
+NAME=${1:-"Liquorix Builder"}
+EMAIL=${2:-"builder@liquorix.net"}
+
+echo "Generating GPG key for $NAME <$EMAIL>..."
+
+mkdir -p ~/.gnupg
+chmod 700 ~/.gnupg
+
+# Generate key non-interactively if it does not already exist
+if ! gpg --list-secret-keys "$EMAIL" >/dev/null 2>&1; then
+    gpg --batch --passphrase '' --quick-generate-key "$NAME <$EMAIL>" default default never
+else
+    echo "Key for $EMAIL already exists, skipping generation."
+fi
+
+# Extract the key ID
+KEY_ID=$(gpg --list-secret-keys --with-colons "$EMAIL" | awk -F: '/^sec:/ {print $5}' | head -n 1)
+
+if [ -z "$KEY_ID" ]; then
+    echo "Error: Failed to find the generated key ID."
+    exit 1
+fi
+
+echo "Generated Key ID: $KEY_ID"
+
+# Add it as the default key only if it's not already set
+if ! grep -q "^default-key $KEY_ID" ~/.gnupg/gpg.conf 2>/dev/null; then
+    echo "default-key $KEY_ID" >> ~/.gnupg/gpg.conf
+fi
+
+echo "Done! The key ($KEY_ID) has been set as your default-key in ~/.gnupg/gpg.conf."


### PR DESCRIPTION
This pull request introduces improvements to GPG key management and package signing in the Debian build scripts. The changes automate GPG key generation and ensure that package builds are signed with the default GPG key if available. Additionally, some unnecessary Docker options have been removed to streamline the build process.

**GPG Key Handling and Package Signing:**

* Added a new script `generate_gpg_key.sh` to automate GPG key creation and configuration, allowing users to specify their name and email or use defaults. The script sets the generated key as the default in `~/.gnupg/gpg.conf`.
* Updated `container_build-binary.sh` and `env.sh` to detect the default GPG key from `~/.gnupg/gpg.conf` and use it for signing packages with `dpkg-buildpackage` if available; otherwise, builds proceed unsigned. [[1]](diffhunk://#diff-8e1c2bf79d5068a813fc20270be086491326ac29f7b44e151b9163b98678dbafR55-R63) [[2]](diffhunk://#diff-35f6edc7993e223dc30a9401eaff06912c9bd561a8590050fe8ca959d7802d53R125-R132)

**Build Process Simplification:**

* Removed the `--tmpfs /build:exec` option from Docker commands in `docker_build-source.sh` and `docker_submit-ppa-sources.sh`, simplifying the container setup for source builds and uploads. [[1]](diffhunk://#diff-a47264f64521e1f012f85db81e673c537e26e99c00649d9d021f20b00296e087L25) [[2]](diffhunk://#diff-5d8dfd811ff5fc3ded05e46b75294cd25153e6759ec17b81b7ddbeadfff9b979L20)